### PR TITLE
Add Go example tests for pkg.go.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ type Options struct {
 func FromContext(ctx context.Context) *Options
 ```
 
-FromContext fetchs options from provided context if no options found, return nil
+FromContext fetches options from provided context. If no options are found, it returns nil.
 
 <details><summary>Example</summary>
 <p>
@@ -113,17 +113,16 @@ import (
 func main() {
 	ctx := context.Background()
 
-	// Without any options set, FromContext returns an empty Options
+	// Without any options set, FromContext returns nil
 	opts := options.FromContext(ctx)
-	_, found := opts.Get("missing-key")
-	fmt.Println("found:", found)
+	fmt.Println("opts:", opts)
 }
 ```
 
 #### Output
 
 ```
-found: false
+opts: <nil>
 ```
 
 </p>

--- a/example_test.go
+++ b/example_test.go
@@ -30,9 +30,8 @@ func ExampleAddToOptions() {
 func ExampleFromContext() {
 	ctx := context.Background()
 
-	// Without any options set, FromContext returns an empty Options
+	// Without any options set, FromContext returns nil
 	opts := options.FromContext(ctx)
-	_, found := opts.Get("missing-key")
-	fmt.Println("found:", found)
-	// Output: found: false
+	fmt.Println("opts:", opts)
+	// Output: opts: <nil>
 }

--- a/options.go
+++ b/options.go
@@ -16,8 +16,8 @@ type Options struct {
 	sync.Map
 }
 
-// FromContext fetchs options from provided context
-// if no options found, return nil
+// FromContext fetches options from provided context.
+// If no options are found, it returns nil.
 func FromContext(ctx context.Context) *Options {
 	if h := ctx.Value(optionsKey); h != nil {
 		if options, ok := h.(*Options); ok {


### PR DESCRIPTION
## Summary
- Add `example_test.go` with examples for `AddToOptions` and `FromContext`
- Examples appear on pkg.go.dev as runnable documentation
- Regenerate README via gomarkdoc

## Test plan
- [ ] `make test` passes
- [ ] Verify examples appear on pkg.go.dev after merge