### PR TITLE
feat: add SupportPackageIsVersion1 compile-time version sentinel

### DIFF
--- a/options.go
+++ b/options.go
@@ -5,6 +5,10 @@ import (
 	"sync"
 )
 
+// SupportPackageIsVersion1 is a compile-time assertion constant.
+// Downstream packages reference this to enforce version compatibility.
+const SupportPackageIsVersion1 = true
+
 type contextKey string
 
 var (


### PR DESCRIPTION
## Summary
- Add `SupportPackageIsVersion1` constant following the gRPC `SupportPackageIsVersion` pattern
- Downstream packages reference this constant to enforce version compatibility at compile time
- When a breaking change is made, export a new version and remove the old one to force coordinated updates

## Test plan
- [x] `go build ./...` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added internal version assertion constant to support package compatibility verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->